### PR TITLE
vendorディレクトリ配下をgit管理対象から削除

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,4 @@
 /config/master.key
 
 # Ignore /vendor/bundle
-/vendor/bundle
+/vendor


### PR DESCRIPTION
題名の通り